### PR TITLE
ci: Publish to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,21 @@ on:
     types:
       - created
 
-
 jobs:
   build:
     name: Linux Py${{ matrix.PYTHON_VERSION }}
     runs-on: ubuntu-latest
     env:
-      CI: 'true'
-      OS: 'linux'
+      CI: "true"
+      OS: "linux"
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.8']
+        PYTHON_VERSION: ["3.10"]
     timeout-minutes: 10
+    permissions:
+      id-token: write
     steps:
       - uses: actions/cache@v1
         with:
@@ -31,12 +32,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
-          architecture: 'x64'
+          architecture: "x64"
       - run: python -m pip install --upgrade pip setuptools wheel twine
       - name: Build and publish python-language-server
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PYLS_TOKEN }}
         run: |
           python setup.py bdist_wheel --universal
           python setup.py sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.urls]
-Homepage = "https://github.com/python-lsp/python-lsp-server"
+Homepage = "https://github.com/deepnote/python-lsp-server"
 
 [project.optional-dependencies]
 all = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Build pipeline updated to target Python 3.10.
  - Release workflow permissions tightened for improved security.
  - Legacy publishing credentials removed from the release process.
  - Workflow configuration standardized for consistency.
  - Project homepage URL updated to the new repository location.
- Note
  - No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->