### PR TITLE
fix: Package name for releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["setuptools>=61.2.0", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "python-lsp-server"
+name = "deepnote-python-lsp-server"
 authors = [{name = "Python Language Server Contributors"}]
 description = "Python Language Server for the Language Server Protocol"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ from setuptools import setup
 
 if __name__ == "__main__":
     setup(
-        name="python-lsp-server",  # to allow GitHub dependency tracking work
+        name="deepnote-python-lsp-server",  # to allow GitHub dependency tracking work
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Renamed the published package to “deepnote-python-lsp-server.”
  - Update your dependency references (e.g., pip install, requirements.txt, pyproject) to the new name.
  - No functional or runtime changes; existing behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->